### PR TITLE
240125 노솔진

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,6 @@ dependencies {
 test {
 	useJUnitPlatform()
 }
+compileJava {
+	options.compilerArgs += ["-parameters"]
+}

--- a/src/main/java/com/erp/ezen25/controller/CommonController.java
+++ b/src/main/java/com/erp/ezen25/controller/CommonController.java
@@ -6,7 +6,6 @@ import com.erp.ezen25.service.ImportService;
 import com.erp.ezen25.service.RequestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,14 +17,13 @@ import java.util.List;
 @Log4j2
 @RequiredArgsConstructor
 public class CommonController {
-    @Autowired
-    private BrandService brandService;
-    @Autowired
-    private RequestService requestService;
-    @Autowired
-    private ImportService importService;
-    @Autowired
-    private ImportCheckService importCheckService;
+    private final BrandService brandService;
+
+    private final RequestService requestService;
+
+    private final ImportService importService;
+
+    private final ImportCheckService importCheckService;
 
     @PostMapping("/brandSelectDelete")
     public String brandSelectDelete(@RequestParam("brandDeleteList") List<Long> brand_ids) {

--- a/src/main/java/com/erp/ezen25/controller/RequestController.java
+++ b/src/main/java/com/erp/ezen25/controller/RequestController.java
@@ -167,6 +167,7 @@ public class RequestController {
 
         importService.remove(importId);
 
+
         return "redirect:/ezen25/request/import/list";
     }
 
@@ -244,6 +245,13 @@ public class RequestController {
         log.info("Post Remove. requestId : " + importCheckId);
 
         importCheckService.remove(importCheckId);
+
+        return "redirect:/ezen25/request/importCheck/list";
+    }
+
+    @PostMapping("/importCheck/review")
+    public String icReview(@RequestParam("importCheckId") Long importCheckId, @RequestParam("num") Long num) {
+        importCheckService.review(importCheckId, num);
 
         return "redirect:/ezen25/request/importCheck/list";
     }

--- a/src/main/java/com/erp/ezen25/entity/ImportCheck.java
+++ b/src/main/java/com/erp/ezen25/entity/ImportCheck.java
@@ -1,13 +1,12 @@
 package com.erp.ezen25.entity;
 
 import jakarta.persistence.*;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.*;
 
 @Entity
 @Builder

--- a/src/main/java/com/erp/ezen25/repository/ImportCheckRepository.java
+++ b/src/main/java/com/erp/ezen25/repository/ImportCheckRepository.java
@@ -1,8 +1,17 @@
 package com.erp.ezen25.repository;
 
+import com.erp.ezen25.entity.Import;
 import com.erp.ezen25.entity.ImportCheck;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
+import java.util.Optional;
+
 public interface ImportCheckRepository extends JpaRepository<ImportCheck, Long>, QuerydslPredicateExecutor<ImportCheck> {
+    ImportCheck findImportCheckByImportCheckId(Long importCheckId);
+
+    ImportCheck findImportCheckByImportId(Import importId);
+    Optional<ImportCheck> findByImportId(Import importId);
+
+
 }

--- a/src/main/java/com/erp/ezen25/repository/ImportRepository.java
+++ b/src/main/java/com/erp/ezen25/repository/ImportRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 public interface ImportRepository extends JpaRepository<Import, Long>, QuerydslPredicateExecutor<Import> {
     Import findImportByImportId(Long importId);
+
+
 }

--- a/src/main/java/com/erp/ezen25/service/ImportCheckService.java
+++ b/src/main/java/com/erp/ezen25/service/ImportCheckService.java
@@ -15,6 +15,7 @@ public interface ImportCheckService {
     ImportCheckDTO read(Long importCheckId);
 
     void remove(Long importCheckId);
+    void review(Long importCheckId, Long requestNum);
 
     void modify(ImportCheckDTO importCheckDTO);
 

--- a/src/main/resources/templates/ezen25/request/import/list.html
+++ b/src/main/resources/templates/ezen25/request/import/list.html
@@ -80,11 +80,9 @@
                         </div>
                         <div class="table_section padding_infor_info">
                             <div class="table-responsive-sm">
-                                <form action="/ezen25/common/importSelectDelete" method="post">
                                     <table class="table" style="text-align:center;">
                                         <thead>
                                         <tr>
-                                            <th><input id="selectAll" type="checkbox"></th>
                                             <th>#</th>
                                             <th>품목 코드</th>
                                             <th>개수</th>
@@ -92,19 +90,11 @@
                                             <th>요청서 코드</th>
                                             <th>상태</th>
                                             <th>
-                                                <button class="new-button"
-                                                        onclick="return importDeleteSelected()"
-                                                        type="submit">
-                                                    선택 삭제
-                                                </button>
                                             </th>
                                         </tr>
                                         </thead>
                                         <tbody>
                                         <tr th:each="importDTO : ${importResult.dtoList}">
-                                            <td><input name="importDeleteList" th:value="${importDTO.importId}"
-                                                       type="checkbox">
-                                            </td>
                                             <input name="importId" th:value="${importDTO.importId}" type="hidden">
                                             <td>
                                                 <a th:href="@{/ezen25/request/import/read(importId = ${importDTO.importId}, page= ${importResult.page},
@@ -118,14 +108,13 @@
                                             <td>[[${importDTO.requestCode}]]</td>
                                             <td>[[${importDTO.importStatus}]]</td>
                                             <td>
-                                                <button class="removeBtn" onclick="confirmDelete()">
+                                                <button class="removeBtn">
                                                     출하
                                                 </button>
                                             </td>
                                         </tr>
                                         </tbody>
                                     </table>
-                                </form>
                                 <ul class="pagination h-100 justify-content-center align-items-center">
                                     <li class="page-item " th:if="${importResult.prev}">
                                         <a class="page-link" tabindex="-1" th:href="@{/ezen25/request/import/list(page = ${importResult.start-1}, type=${pageRequestDTO.type},
@@ -166,61 +155,36 @@
             });
 
         </script>
-        <script th:inline="javascript">
-            var actionForm = $("form");
+        <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
 
-            function confirmDelete() {
-                if(confirm("삭제하겠습니까?")) {
-                        alert("삭제가 완료되었습니다.");
-                        actionForm
-                        .attr("action", "/ezen25/request/import/remove")
-                        .attr("method", "post");
+        <script>
+            // 출하 버튼 클릭 시 AJAX를 통해 importId를 서버로 전송하고 해당 기록 삭제
+            $(".removeBtn").click(function () {
+                // 현재 버튼이 속한 행에서 importId 값을 가져오기
+                var importId = $(this).closest('tr').find('[name="importId"]').val();
 
-                    actionForm.submit();
-                } else {
+                // 사용자에게 삭제 여부를 묻기
+                var confirmRemove = confirm("이 수입 기록을 삭제하시겠습니까?");
+                if (!confirmRemove) {
                     return;
                 }
 
-            }
+                // AJAX 요청 설정
+                $.ajax({
+                    type: "POST",
+                    url: "/ezen25/request/import/remove",
+                    data: { "importId": importId },
+                    success: function (response) {
+                        // 삭제 성공 시 import 목록 페이지로 리다이렉트
+                        window.location.href = '/ezen25/request/import/list';
+                    },
+                    error: function (error) {
+                        console.error("수입 기록 삭제 중 오류 발생: " + error);
+                        // 오류 처리를 추가하십시오 (예: 사용자에게 알림)
+                    }
+                });
+            });
         </script>
-        <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
-        <script th:inline="javascript">
-            $(document).ready(function() {
-              // 전체 선택 체크박스
-              $("#selectAll").click(function() {
-                  $("input[name='importDeleteList']").prop('checked', this.checked);
-              });
-          });
-          // 선택 삭제 함수
-          function importDeleteSelected() {
-              var selectedItems = [];
-
-              // 선택된 체크박스 가져오기
-              $('input[name="importDeleteList"]:checked').each(function() {
-                  selectedItems.push($(this).val());
-              });
-
-              // 선택된 항목이 없을 경우 알림
-              if (selectedItems.length === 0) {
-                  alert("선택된 항목이 없습니다.");
-                  return false;
-              }
-
-              // 사용자에게 삭제 여부 확인
-              var isConfirmed = confirm("선택한 항목을 삭제하시겠습니까?");
-
-              // 사용자가 확인을 눌렀을 때 삭제 요청
-              if (isConfirmed) {
-                  console.log("deleteSelected 함수 호출됨");
-                  alert("삭제완료");
-                  return true;
-
-              } else {
-                  return false;
-              }
-          }
-        </script>
-
     </main>
 </th:block>
 </html>

--- a/src/main/resources/templates/ezen25/request/importCheck/list.html
+++ b/src/main/resources/templates/ezen25/request/importCheck/list.html
@@ -78,29 +78,38 @@
 
                             </div>
                         </div>
+                        <div class="modal fade" id="reviewModal" tabindex="-1" role="dialog" aria-labelledby="reviewModalLabel" aria-hidden="true">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title" id="reviewModalLabel">숫자를 입력하세요</h5>
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                            <span aria-hidden="true">&times;</span>
+                                        </button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <input type="text" id="numInput" class="form-control" placeholder="숫자를 입력하세요">
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">닫기</button>
+                                        <button type="button" class="btn btn-primary" id="submitBtn">확인</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="table_section padding_infor_info">
                             <div class="table-responsive-sm">
-                                <form action="/ezen25/common/icSelectDelete" method="post">
                                     <table class="table" style="text-align:center;">
                                         <thead>
                                         <tr>
-                                            <th><input id="selectAll" type="checkbox"></th>
                                             <th>#</th>
                                             <th>입고 번호</th>
                                             <th>상태</th>
-                                            <th>
-                                                <button class="new-button" onclick="return icDeleteSelected()"
-                                                        type="submit">
-                                                    <strong>선택 삭제</strong>
-                                                </button>
-                                            </th>
+                                            <th></th>
                                         </tr>
                                         </thead>
                                         <tbody>
                                         <tr th:each="icDTO : ${icResult.dtoList}">
-                                            <td><input name="icDeleteList" th:value="${icDTO.importCheckId}"
-                                                       type="checkbox">
-                                            </td>
                                             <input name="importCheckId" th:value="${icDTO.importCheckId}" type="hidden">
                                             <td>
                                                 <a th:href="@{/ezen25/request/importCheck/read(importCheckId = ${icDTO.importCheckId}, page= ${icResult.page},
@@ -110,11 +119,18 @@
                                             </td>
                                             <td>[[${icDTO.importId}]]</td>
                                             <td>[[${icDTO.importCheckStatus}]]</td>
-                                            <td>a</td>
+                                            <td>
+                                                <button class="removeBtn" onclick="confirmDelete(this)">
+                                                    검수완료
+                                                </button>
+                                                <button class="reviewBtn" onclick="openReviewModal(this)">
+                                                    반품처리
+                                                    <input name="importCheckId" th:value="${icDTO.importCheckId}" type="hidden">
+                                                </button>
+                                            </td>
                                         </tr>
                                         </tbody>
                                     </table>
-                                </form>
                                 <ul class="pagination h-100 justify-content-center align-items-center">
                                     <li class="page-item " th:if="${icResult.prev}">
                                         <a class="page-link" tabindex="-1" th:href="@{/ezen25/request/importCheck/list(page = ${icResult.start-1}, type=${pageRequestDTO.type},
@@ -138,6 +154,51 @@
                 </div>
             </div>
         </div>
+        <script>
+            function openReviewModal(button) {
+                // 나중에 사용할 수 있도록 모달에 importCheckId 설정
+                var importCheckId = $(button).closest('tr').find('[name="importCheckId"]').val();
+                console.log('importCheckId:', importCheckId); // 추가된 로그
+                $('#reviewModal').data('importCheckId', importCheckId); // 변경된 부분
+
+                // 모달 표시
+                $('#reviewModal').modal('show');
+            }
+
+            $(document).ready(function () {
+                $("#submitBtn").click(function () {
+                    var num = $("#numInput").val();
+                    var importCheckId = $('#reviewModal').data('importCheckId');
+                    console.log('data-importCheckId:', importCheckId); // 추가된 로그
+
+                    if (!isNaN(num) && num !== "" && importCheckId !== undefined) {
+                        $.ajax({
+                            type: "POST",
+                            url: "/ezen25/request/importCheck/review",
+                            data: {
+                                importCheckId: importCheckId,
+                                num: num
+                            },
+                            success: function (data) {
+                                // 처리가 성공한 경우 리다이렉트
+                                window.location.href = "/ezen25/request/importCheck/list";
+                            },
+                            error: function (xhr, status, error) {
+                                console.error('에러:', error);
+                            }
+                        });
+
+                        $('#reviewModal').modal('hide'); // 모달 닫기
+                    } else {
+                        alert("올바른 숫자를 입력하세요.");
+                    }
+                });
+            });
+        </script>
+
+
+
+
         <script th:inline="javascript">
 
             var searchForm = $("#searchForm");
@@ -155,43 +216,35 @@
             });
 
         </script>
-        <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
         <script th:inline="javascript">
-            $(document).ready(function() {
-              // 전체 선택 체크박스
-              $("#selectAll").click(function() {
-                  $("input[name='icDeleteList']").prop('checked', this.checked);
-              });
-          });
-          // 선택 삭제 함수
-          function icDeleteSelected() {
-              var selectedItems = [];
+            function confirmDelete(button) {
+                if (confirm('정말로 삭제하시겠습니까?')) {
+                    // Get the importCheckId from the hidden input field in the same row
+                    var importCheckId = $(button).closest('tr').find('input[name="importCheckId"]').val();
 
-              // 선택된 체크박스 가져오기
-              $('input[name="icDeleteList"]:checked').each(function() {
-                  selectedItems.push($(this).val());
-              });
+                    // Alternatively, you can use pure JavaScript to get the value
+                    // var importCheckId = document.getElementsByName('importCheckId')[0].value;
 
-              // 선택된 항목이 없을 경우 알림
-              if (selectedItems.length === 0) {
-                  alert("선택된 항목이 없습니다.");
-                  return false;
-              }
+                    // If the user confirms, send an Ajax request to delete the record
+                    $.ajax({
+                        type: 'POST',
+                        url: '/ezen25/request/importCheck/remove',
+                        data: { importCheckId: importCheckId },
+                        success: function (data) {
+                            // Optionally, handle the response from the server
+                            console.log('Delete response:', data);
 
-              // 사용자에게 삭제 여부 확인
-              var isConfirmed = confirm("선택한 항목을 삭제하시겠습니까?");
-
-              // 사용자가 확인을 눌렀을 때 삭제 요청
-              if (isConfirmed) {
-                  console.log("deleteSelected 함수 호출됨");
-                  alert("삭제완료");
-                  return true;
-
-              } else {
-                  return false;
-              }
-          }
+                            // Redirect to the list page after successful deletion
+                            window.location.href = '/ezen25/request/importCheck/list';
+                        },
+                        error: function (error) {
+                            console.error('Error deleting record:', error);
+                        }
+                    });
+                }
+            }
         </script>
+
     </main>
 </th:block>
 </html>


### PR DESCRIPTION
- 입고 대기 페이지에서 출하 버튼 누르면 입고 검수 페이지에서 검수완료/반품처리 버튼을 추가
- 검수 완료 시 요청 페이지의 상태가 완료로 바뀌고, 검수 페이지에서는 해당 검수 대상이 삭제됨. 
- 반품 처리 시 검수 대상이 삭제되고, 모달이 나타나서 정상 물품 개수를 입력하고 입고 대기 페이지의 개수는 처음 개수 - 정상 물품 개수가 되도록 구현.
- 입고 대기 페이지의 상태는 얼마나 %로 완료되었는지 표시되게 구현. (정상 물품 개수 / 전체 요청 물품 개수)
